### PR TITLE
fix: fetch auth explicitly before checking usage limits to prevent error

### DIFF
--- a/functions/routes/ecom/modules/apply-discount.js
+++ b/functions/routes/ecom/modules/apply-discount.js
@@ -71,11 +71,12 @@ ${discountedSkus.map((sku) => `\n${sku}: ${discountPerSku[sku].toFixed(2)}`)}
         query: '',
         max: discountRule.total_usage_limit
       }]
+      const auth = await appSdk.getAuth(storeId)
       for (let i = 0; i < usageLimits.length; i++) {
         const { query, max } = usageLimits[i]
         if (max) {
           // send Store API request to list orders with filters
-          const { response } = await appSdk.apiRequest(storeId, `${url}${query}`)
+          const { response } = await appSdk.apiRequest(storeId, `${url}${query}`, 'GET', null, auth)
           const countOrders = response.data.result
             .filter(({ status }) => status !== 'cancelled')
             .length
@@ -462,6 +463,7 @@ ${discountedSkus.map((sku) => `\n${sku}: ${discountPerSku[sku].toFixed(2)}`)}
                 discountedItemIds = discountedItemIds.concat(kitItems.map(item => item.product_id))
               }
             } catch (err) {
+              console.error(`CANT_CHECK_USAGE_LIMITS store #${storeId}:`, err)
               return res.status(409).send({
                 error: 'CANT_CHECK_USAGE_LIMITS',
                 message: err.message
@@ -505,7 +507,7 @@ ${discountedSkus.map((sku) => `\n${sku}: ${discountPerSku[sku].toFixed(2)}`)}
         if (
           checkOpenPromotion(discountRule) &&
           discountRule.discount.apply_at === 'freight' &&
-          !params.amount?.freight
+          !(params.amount && params.amount.freight)
         ) {
           const { discountRule: altRule, discountMatchEnum: altEnum } = matchDiscountRule(discountRules, params, 'freight')
           if (altRule) {
@@ -671,6 +673,7 @@ ${discountedSkus.map((sku) => `\n${sku}: ${discountPerSku[sku].toFixed(2)}`)}
               addFreebies()
               return respondSuccess()
             } catch (err) {
+              console.error(`CANT_CHECK_USAGE_LIMITS store #${storeId}:`, err)
               return res.status(409).send({
                 error: 'CANT_CHECK_USAGE_LIMITS',
                 message: err.message


### PR DESCRIPTION
Lojas com cupons configurados com usage_limit ou total_usage_limit recebiam o erro CANT_CHECK_USAGE_LIMITS com status 409 ao tentar aplicar o desconto.

A causa: checkUsageLimit chamava appSdk.apiRequest(storeId, url) sem passar o objeto auth, dependendo do auto-fetch interno do SDK. Esse mecanismo passou a falhar com 401 para algumas lojas após a migração do Firebase Functions v4 → v5.

Solução
appSdk.getAuth(storeId) é agora chamado explicitamente antes das requisições à Store API, e o auth resultante é passado diretamente para apiRequest — padrão já utilizado em discount-rules.js e get-app-data.js
Adicionado console.error nos dois catch blocks de CANT_CHECK_USAGE_LIMITS para que ocorrências futuras apareçam nos logs do Firebase com o store_id e o erro completo

Impacto
Lojas sem usage_limit configurado não são afetadas (o checkUsageLimit retorna true imediatamente sem fazer nenhuma chamada à API).