### PR TITLE
feat(discount): restrict discount rule to selected products' subtotal

### DIFF
--- a/assets/application.json
+++ b/assets/application.json
@@ -183,6 +183,11 @@
                 "title": "ID do produto"
               }
             },
+            "discount_products_subtotal": {
+              "type": "boolean",
+              "title": "Descontar apenas produtos selecionados",
+              "description": "Se ativo, o desconto será calculado apenas sobre o subtotal dos produtos da campanha (`product_ids`) presentes no carrinho, e não sobre o carrinho inteiro"
+            },
             "excluded_product_ids": {
               "title": "Produtos excluídos",
               "description": "Se preenchido, o desconto será inválido se um dos produtos estiver no carrinho",

--- a/functions/ecom.config.js
+++ b/functions/ecom.config.js
@@ -287,6 +287,11 @@ const app = {
                 "title": "ID do produto"
               }
             },
+            "discount_products_subtotal": {
+              "type": "boolean",
+              "title": "Descontar apenas produtos selecionados",
+              "description": "Se ativo, o desconto será calculado apenas sobre o subtotal dos produtos da campanha (`product_ids`) presentes no carrinho, e não sobre o carrinho inteiro"
+            },
             "excluded_product_ids": {
               "title": "Produtos excluídos",
               "description": "Se preenchido, o desconto será inválido se um dos produtos estiver no carrinho",

--- a/functions/lib/helpers.js
+++ b/functions/lib/helpers.js
@@ -271,6 +271,17 @@ const mapCampaignProducts = (rule, params) => {
   return { valid: true, items: [] }
 }
 
+const getCampaignDiscountAmount = (rule, params, filteredItems) => {
+  if (Array.isArray(filteredItems) && filteredItems.length) {
+    // cap the discount base to the subtotal of the selected campaign products
+    return filteredItems.reduce((subtotal, item) => {
+      return subtotal + (ecomUtils.price(item) * (item.quantity || 1))
+    }, 0)
+  }
+  const applyAt = (rule.discount && rule.discount.apply_at) || 'total'
+  return (params.amount && params.amount[applyAt]) || 0
+}
+
 module.exports = {
   validateDateRange,
   validateCustomerId,
@@ -278,5 +289,6 @@ module.exports = {
   getValidDiscountRules,
   matchDiscountRule,
   matchFreebieRule,
-  mapCampaignProducts
+  mapCampaignProducts,
+  getCampaignDiscountAmount
 }

--- a/functions/lib/helpers.test.js
+++ b/functions/lib/helpers.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const assert = require('assert')
+const { getCampaignDiscountAmount } = require('./helpers')
+
+const params = {
+  amount: {
+    total: 300,
+    subtotal: 300,
+    freight: 0
+  },
+  items: [
+    {
+      product_id: 'prod-1',
+      sku: 'SKU-1',
+      quantity: 1,
+      price: 100,
+      price_final: 100,
+      categories: []
+    },
+    {
+      product_id: 'prod-2',
+      sku: 'SKU-2',
+      quantity: 1,
+      price: 200,
+      price_final: 200,
+      categories: []
+    }
+  ]
+}
+
+const rule = {
+  product_ids: ['prod-1'],
+  discount: {
+    type: 'percentage',
+    value: 10,
+    apply_at: 'total'
+  }
+}
+
+const filteredItems = params.items.filter(item => rule.product_ids.includes(item.product_id))
+
+assert.strictEqual(
+  getCampaignDiscountAmount(rule, params, filteredItems),
+  100,
+  'should cap the discount base to the selected product subtotal'
+)
+
+console.log('helpers test ok')

--- a/functions/routes/ecom/modules/apply-discount.js
+++ b/functions/routes/ecom/modules/apply-discount.js
@@ -7,7 +7,8 @@ const {
   getValidDiscountRules,
   matchDiscountRule,
   matchFreebieRule,
-  mapCampaignProducts
+  mapCampaignProducts,
+  getCampaignDiscountAmount
 } = require('../../../lib/helpers')
 
 exports.post = ({ appSdk, admin }, req, res) => {
@@ -594,7 +595,10 @@ ${discountedSkus.map((sku) => `\n${sku}: ${discountPerSku[sku].toFixed(2)}`)}
           }
 
           // we have a discount to apply \o/
-          const discountValue = addDiscount(discountRule.discount, discountMatchEnum)
+          const maxDiscount = discountRule.discount_products_subtotal
+            ? getCampaignDiscountAmount(discountRule, params, filteredItems)
+            : undefined
+          const discountValue = addDiscount(discountRule.discount, discountMatchEnum, undefined, maxDiscount)
           if (discountValue) {
             if (filteredItems?.length) {
               pointDiscountToEachItem(discountValue, filteredItems)


### PR DESCRIPTION
## Summary
- Adds an opt-in `discount_products_subtotal` flag to `discount_rules` (schema in `functions/ecom.config.js` and mirrored in `assets/application.json`).
- When enabled on a rule, the discount value is calculated over the subtotal of only the campaign products (`product_ids`) present in the cart, instead of the whole cart total/subtotal.
- Default behavior (flag off) is unchanged — existing merchants keep applying the discount to the whole cart, as today.
- New pure helper `getCampaignDiscountAmount` in `functions/lib/helpers.js`, used from `functions/routes/ecom/modules/apply-discount.js` to cap the discount base when the flag is on.

## Test plan
- [x] `node functions/lib/helpers.test.js` passes (covers `getCampaignDiscountAmount` capping to the selected product's subtotal)
- [x] Manual end-to-end simulation of `apply-discount.post` with a 2-item cart (prod-1 R$100 + prod-2 R$200) and a 10% rule:
  - flag off → `extra_discount.value = 30` (10% of the whole R$300 cart, legacy behavior)
  - flag on → `extra_discount.value = 10` (10% of only prod-1's R$100)
  - flag on + quantity 2 on prod-1 → `extra_discount.value = 20` (10% of R$200)
- [x] `ecom.config.js` and `assets/application.json` parse correctly after the schema addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)